### PR TITLE
Fix CSRF token fetching

### DIFF
--- a/src/auth_cookie.rs
+++ b/src/auth_cookie.rs
@@ -14,16 +14,17 @@ pub fn get_auth_cookie() -> Option<SecretString> {
 }
 
 pub fn get_csrf_token(roblosecurity_cookie: &SecretString) -> Result<HeaderValue, RobloxApiError> {
+    let cookie_header = format!(".ROBLOSECURITY={}", roblosecurity_cookie.expose_secret());
+
     let response = Client::new()
         .post("https://auth.roblox.com")
-        .header(header::COOKIE, roblosecurity_cookie.expose_secret())
+        .header(header::COOKIE, cookie_header)
         .header(header::CONTENT_LENGTH, 0)
-        .send();
+        .send()?;
 
     response
-        .unwrap()
         .headers()
         .get("X-CSRF-Token")
-        .map(|v| v.to_owned())
+        .cloned()
         .ok_or(RobloxApiError::MissingCsrfToken)
 }


### PR DESCRIPTION
## Summary
- properly prefix .ROBLOSECURITY cookie when fetching the CSRF token

## Testing
- `cargo fmt --all` *(fails: rustfmt component missing)*
- `cargo test --quiet` *(fails: could not download crates due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685bec718a688329815626f36e4c78fd